### PR TITLE
Correct documentation to describe what order interceptors are run in

### DIFF
--- a/src/ruby/lib/grpc/generic/interceptors.rb
+++ b/src/ruby/lib/grpc/generic/interceptors.rb
@@ -160,7 +160,7 @@ module GRPC
     end
 
     ##
-    # Intercept the call and fire out to interceptors in a FIFO execution.
+    # Intercept the call and fire out to interceptors in a LIFO execution.
     # This is an EXPERIMENTAL API.
     #
     # @param [Symbol] type The request type

--- a/src/ruby/lib/grpc/generic/rpc_server.rb
+++ b/src/ruby/lib/grpc/generic/rpc_server.rb
@@ -212,6 +212,8 @@ module GRPC
     # * interceptors:
     # An array of GRPC::ServerInterceptor objects that will be used for
     # intercepting server handlers to provide extra functionality.
+    # Interceptors are applied in LIFO order, so the last interceptor
+    # in the array is the first to be executed on a call.
     # Interceptors are an EXPERIMENTAL API.
     #
     def initialize(pool_size: DEFAULT_POOL_SIZE,


### PR DESCRIPTION
What is changing
The current implementation of the Ruby gRPC library applies interceptors in LIFO order to the call. The documentation is being updated to make that information easily discoverable.

Why is it changing
There doesn't appear to be any easily discoverable documentation on the specifics of the interceptor implementation.
One detail that is surprising is that the server interceptors are applied to a call in the reverse order that they are specified in the array.

Whether or not this is the intent of the code it is now part of the API so should be documented / made explicit to avoid further surpised.

Re-raise of https://github.com/grpc/grpc/pull/23752 due to CLA not working.

@markdroth / @apolcyn
<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble